### PR TITLE
fix(security): Block import statements in PythonSandboxTool

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -45,6 +45,17 @@ def test_python_sandbox_blocked():
     assert result.status == ToolStatus.ERROR or result.status == ToolStatus.BLOCKED
 
 
+def test_python_sandbox_blocked_from_import():
+    """Test qu'un code dangereux avec 'from ... import' est bloqué"""
+    tool = PythonSandboxTool()
+
+    # Code avec import dangereux
+    result = tool.execute({"code": "from os import system\nprint('test')"})
+
+    assert not result.is_success()
+    assert result.status == ToolStatus.ERROR or result.status == ToolStatus.BLOCKED
+
+
 def test_calculator_basic():
     """Test basique du calculateur"""
     tool = CalculatorTool()

--- a/tools/python_sandbox.py
+++ b/tools/python_sandbox.py
@@ -131,6 +131,7 @@ class PythonSandboxTool(BaseTool):
         
         # Bloquer certaines opérations dangereuses
         dangerous_patterns = [
+            'import',
             '__import__',
             'eval(',
             'exec(',


### PR DESCRIPTION
Adds the 'import' keyword to the dangerous_patterns list in the PythonSandboxTool to prevent the execution of code containing import statements. This addresses a critical security vulnerability that allowed for arbitrary code execution.

A new test case, `test_python_sandbox_blocked_from_import`, has been added to verify that `from ... import ...` statements are also correctly blocked.