### PR TITLE
Fix conversation fixture primary key insertion

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -720,10 +720,12 @@ def conversation_factory(temp_db):
         # Créer la conversation (respect du schéma réel)
         now_iso = datetime.utcnow().isoformat()
         cursor.execute("""
-            INSERT INTO conversations (conversation_id, created_at, updated_at, metadata)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO conversations (id, conversation_id, task_id, created_at, updated_at, metadata)
+            VALUES (?, ?, ?, ?, ?, ?)
         """, (
             conversation_id,
+            conversation_id,
+            task_id,
             now_iso,
             now_iso,
             None


### PR DESCRIPTION
## Summary
- update the test conversation factory to supply the new conversations.id primary key
- ensure optional task identifiers are stored when creating fixture conversations

## Testing
- `pytest tests/test_memory.py -k conversation -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_690441fa848c8323b74a24725e0b3ea7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update test conversation factory to insert `conversations.id` and optional `task_id` to match the current schema.
> 
> - **Tests**:
>   - **Conversation factory (`tests/conftest.py`)**:
>     - `INSERT INTO conversations` now includes `id` and `task_id` columns.
>     - Values provide `conversation_id` as `id` and pass optional `task_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c91a81e7bcf295a39fbd1f2f388696ac37d0026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->