### PR TITLE
Investigate linter.yml failures

### DIFF
--- a/planner/verifier.py
+++ b/planner/verifier.py
@@ -224,7 +224,7 @@ class TaskVerifier:
             metrics.record_verification(
                 level=level.value,
                 passed=passed,
-                confidence_score=confidence_score,
+                confidence_score=confidence,
             )
             
             # Construire résultat

--- a/runtime/model_interface.py
+++ b/runtime/model_interface.py
@@ -245,7 +245,6 @@ _model_instance: Optional[ModelInterface] = None
 
 def get_model() -> ModelInterface:
     """Récupérer l'instance globale du modèle"""
-    global _model_instance
     if _model_instance is None:
         raise RuntimeError("Model not initialized. Call init_model() first.")
     return _model_instance


### PR DESCRIPTION
Fix two flake8 errors (F821 and F824) to resolve the failing linter workflow.

The linter workflow was failing due to an undefined variable `confidence_score` (should be `confidence`) and an unnecessary `global` declaration for `_model_instance` when only reading it.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c9c353a-2e11-457e-82eb-b4febebc41a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c9c353a-2e11-457e-82eb-b4febebc41a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

