### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,6 @@
 name: Documentation FilAgent
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fil04331/FilAgent/security/code-scanning/13](https://github.com/fil04331/FilAgent/security/code-scanning/13)

To fix the issue, the workflow should explicitly declare a `permissions` block at the root level so it applies to all jobs in the workflow. The minimal set of permissions required is `contents: read`, since the job uses `actions/checkout` (requires `contents: read`) and `actions/upload-artifact` (does not require elevated permissions). Add the following block immediately after the `name:` field and before `on:`, as per GitHub Actions conventions:

```yaml
permissions:
  contents: read
```

This will restrict the GITHUB_TOKEN to read-only permissions on repository contents, adhering to the principle of least privilege and fulfilling the CodeQL recommendation. No additional modifications are needed elsewhere in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
