### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,6 +3,8 @@ name: Python Tests
 
 # Déclencheurs : l'agent se lancera à chaque 'push' et 'pull request'
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/fil04331/FilAgent/security/code-scanning/14](https://github.com/fil04331/FilAgent/security/code-scanning/14)

To fix the problem, add a `permissions` block to the workflow, limiting the GITHUB_TOKEN permissions to the least privilege needed. For this workflow, only reading repository contents is necessary, so set `permissions: contents: read`. This block should be placed at the top level of the workflow YAML (either after the `name:` or after `on:`, but before jobs). Edit `.github/workflows/testing.yml` to insert:

```yaml
permissions:
  contents: read
```

directly beneath (or above) the `on:` block for clarity and conformity with GitHub documentation. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
