### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/runtime/server.py
+++ b/runtime/server.py
@@ -228,7 +228,7 @@ async def chat(request: ChatRequest):
             "choices": [
                 {
                     "index": 0,
-                    "message": {"role": "assistant", "content": f"[stub-error] {str(e)}"},
+                    "message": {"role": "assistant", "content": "[stub-error] An internal error has occurred."},
                     "finish_reason": "error",
                 }
             ],


### PR DESCRIPTION
Potential fix for [https://github.com/fil04331/FilAgent/security/code-scanning/3](https://github.com/fil04331/FilAgent/security/code-scanning/3)

The fix is to ensure that sensitive exception details are not sent back to the end user. Instead of including the exception string (`str(e)`) in the response, return a generic error message such as "An internal error has occurred." Logging should remain unchanged so that server-side logs capture all needed diagnostic information. The fix is to change line 231 in the fallback response definition (`"content": f"[stub-error] {str(e)}"`) to a static generic message, e.g., `"content": "[stub-error] An internal error has occurred."`.

No package or import changes are required for this fix; only the affected line in the definition of `fallback` should be changed. No functional changes apart from this are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
