### PR TITLE
Configure pytest code coverage thresholds

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,13 @@ addopts =
     --tb=short
     --color=yes
     --disable-warnings
+    --cov=runtime
+    --cov=planner
+    --cov=tools
+    --cov=memory
+    --cov-report=term-missing
+    --cov-report=html
+    --cov-fail-under=70
 
 # Marqueurs
 markers =


### PR DESCRIPTION
- Add coverage tracking for runtime, planner, tools, memory modules
- Configure term-missing and HTML coverage reports
- Set minimum coverage threshold at 70%